### PR TITLE
Feature/ORTool API

### DIFF
--- a/backend/services/planner/app/server.py
+++ b/backend/services/planner/app/server.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+import uvicorn
 
 class UserPreference(BaseModel):
     x: int
@@ -26,3 +27,6 @@ async def solve(preference: UserPreference):
             "total_credits": 0
         }
     }
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## 📝 Description

This adds the functionality for the API gateway so that the main.go can handle front-end requests and send to the python server for the OR solver.

## Additional Notes (Optional)

Next steps is either to refactor into jrpc or remove the temporary testing components when full frontend/backend system is established.