### PR TITLE
resize left sidebar, chatbot overflow

### DIFF
--- a/frontend/app/components/Chatbot/ChatContainer.tsx
+++ b/frontend/app/components/Chatbot/ChatContainer.tsx
@@ -51,6 +51,7 @@ export function ChatContainer() {
   return (
     <div
       className="
+      flex-1
       flex flex-col
       m-4"
     >

--- a/frontend/app/components/Chatbot/ChatContainer.tsx
+++ b/frontend/app/components/Chatbot/ChatContainer.tsx
@@ -53,7 +53,8 @@ export function ChatContainer() {
       className="
       flex-1
       flex flex-col
-      m-4"
+      m-4
+      min-h-0"
     >
       <ChatHeader />
 
@@ -87,7 +88,8 @@ const WidgetBody = ({ children }: any) => {
   bg-widget-bg
   border-1 border-widget-border
   grow flex flex-col
-  rounded-b-md"
+  rounded-b-md
+  min-h-0"
     >
       {children}
     </div>

--- a/frontend/app/components/DegreeAudit.tsx
+++ b/frontend/app/components/DegreeAudit.tsx
@@ -3,7 +3,8 @@ export function DegreeAudit() {
     <div
       className="m-4
     border border-black
-    grid place-items-center"
+    grid place-items-center
+    flex-1"
     >
       Degree Audit
     </div>

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -1,15 +1,34 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 export function Sidebar({ children }: any) {
   const sidebarRef = useRef<HTMLDivElement>(null);
   const isResizing = useRef(false);
+
+  useEffect(() => {
+    window.addEventListener("mousemove", doResize);
+    // Mouse down must start on the resize bar, but could end anywhere
+    window.addEventListener("mouseup", stopResize);
+
+    return () => {
+      window.removeEventListener("mousemove", doResize);
+      window.removeEventListener("mouseup", stopResize);
+    };
+  });
+
+  const doResize = (e: MouseEvent) => {
+    if (!isResizing.current || !sidebarRef.current) return;
+    const widthRatio = e.clientX / window.innerWidth;
+    if (widthRatio > 0.05) {
+      // sidebarRef.current.style.
+    }
+  };
 
   const startResize = () => {
     isResizing.current = true;
     document.body.style.cursor = "col-resize";
   };
 
-  const endResize = () => {
+  const stopResize = () => {
     isResizing.current = false;
     document.body.style.cursor = "default";
   };

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -4,7 +4,7 @@ export function Sidebar({ children }: any) {
   const sidebarRef = useRef<HTMLDivElement>(null);
   const isResizing = useRef(false);
 
-  useEffect(() => {
+  const initWidth = useEffect(() => {
     window.addEventListener("mousemove", doResize);
     // Mouse down must start on the resize bar, but could end anywhere
     window.addEventListener("mouseup", stopResize);
@@ -17,32 +17,42 @@ export function Sidebar({ children }: any) {
 
   const doResize = (e: MouseEvent) => {
     if (!isResizing.current || !sidebarRef.current) return;
-    const widthRatio = e.clientX / window.innerWidth;
-    if (widthRatio > 0.05) {
-      sidebarRef.current.style.width = widthRatio * window.innerWidth + "px";
+    const widthRatio = (e.clientX / window.innerWidth) * 100;
+    if (widthRatio > 5) {
+      sidebarRef.current.style.width = widthRatio + "vw";
     }
   };
 
   const startResize = () => {
     isResizing.current = true;
     document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
   };
 
   const stopResize = () => {
     isResizing.current = false;
-    document.body.style.cursor = "default";
+    document.body.style.cursor = "auto";
+    document.body.style.userSelect = "auto";
   };
 
   return (
     <div
       ref={sidebarRef}
-      style={{ width: 0.3 * window.innerWidth }}
+      style={{ width: "30vw", minWidth: "20vw", maxWidth: "80vw" }}
       className="
         flex flex-col
-        border-r"
+        border-r
+        relative"
     >
       {children}
-      <div onMouseDown={startResize} className=""></div>
+
+      <div
+        onMouseDown={startResize}
+        className="
+        absolute right-0 top-0 h-full w-1
+        cursor-col-resize
+        "
+      ></div>
     </div>
   );
 }

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -1,0 +1,11 @@
+export function Sidebar({ children }: any) {
+  return (
+    <div
+      className="
+              col-span-1 grid grid-rows-2
+              border-r"
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -19,7 +19,7 @@ export function Sidebar({ children }: any) {
     if (!isResizing.current || !sidebarRef.current) return;
     const widthRatio = e.clientX / window.innerWidth;
     if (widthRatio > 0.05) {
-      // sidebarRef.current.style.
+      sidebarRef.current.style.width = widthRatio * window.innerWidth + "px";
     }
   };
 
@@ -36,9 +36,10 @@ export function Sidebar({ children }: any) {
   return (
     <div
       ref={sidebarRef}
+      style={{ width: 0.3 * window.innerWidth }}
       className="
-              col-span-1 grid grid-rows-2
-              border-r"
+        flex flex-col
+        border-r"
     >
       {children}
       <div onMouseDown={startResize} className=""></div>

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -1,11 +1,28 @@
+import { useRef } from "react";
+
 export function Sidebar({ children }: any) {
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const isResizing = useRef(false);
+
+  const startResize = () => {
+    isResizing.current = true;
+    document.body.style.cursor = "col-resize";
+  };
+
+  const endResize = () => {
+    isResizing.current = false;
+    document.body.style.cursor = "default";
+  };
+
   return (
     <div
+      ref={sidebarRef}
       className="
               col-span-1 grid grid-rows-2
               border-r"
     >
       {children}
+      <div onMouseDown={startResize} className=""></div>
     </div>
   );
 }

--- a/frontend/app/routes/dashboard.tsx
+++ b/frontend/app/routes/dashboard.tsx
@@ -7,16 +7,17 @@ export default function Dashboard() {
   // TODO: redirect to login page if user isn't logged in
   return (
     <div className="grid grid-cols-4 h-screen">
+      {/* sidebar */}
       <div
         className="
         col-span-1 grid grid-rows-2
-        border-r
-        "
+        border-r"
       >
         <DegreeAudit />
         <ChatContainer />
       </div>
 
+      {/* primary widget */}
       <div
         className="col-span-3
         flex-row"

--- a/frontend/app/routes/dashboard.tsx
+++ b/frontend/app/routes/dashboard.tsx
@@ -7,7 +7,7 @@ import { Sidebar } from "~/components/Sidebar";
 export default function Dashboard() {
   // TODO: redirect to login page if user isn't logged in
   return (
-    <div className="grid grid-cols-4 h-screen">
+    <div className="grid grid-cols-[min-content_1fr] h-screen">
       <Sidebar>
         <DegreeAudit />
         <ChatContainer />
@@ -15,7 +15,7 @@ export default function Dashboard() {
 
       {/* primary widget */}
       <div
-        className="col-span-3
+        className="
         flex-row"
       >
         <SelectPlan />

--- a/frontend/app/routes/dashboard.tsx
+++ b/frontend/app/routes/dashboard.tsx
@@ -2,20 +2,16 @@ import { DegreeAudit } from "~/components/DegreeAudit";
 import { Calendar } from "~/components/Calendar";
 import { SelectPlan } from "~/components/SelectPlan";
 import { ChatContainer } from "~/components/Chatbot/ChatContainer";
+import { Sidebar } from "~/components/Sidebar";
 
 export default function Dashboard() {
   // TODO: redirect to login page if user isn't logged in
   return (
     <div className="grid grid-cols-4 h-screen">
-      {/* sidebar */}
-      <div
-        className="
-        col-span-1 grid grid-rows-2
-        border-r"
-      >
+      <Sidebar>
         <DegreeAudit />
         <ChatContainer />
-      </div>
+      </Sidebar>
 
       {/* primary widget */}
       <div


### PR DESCRIPTION
## 📝 Description

Add bar to resize left column, fix chatbot overflow

---

## 🧪 How to Test

Drag around the left sidebar border, it should have reasonable min/max values on either side, and the components within should handle resizing properly. Entering repeated messages into the chatbot should create a scroll bar within, though spamming it breaks things. Text wrap also broke in the last commit I believe..

---

## 📸 Screenshots (if applicable)

<img width="1013" height="882" alt="image" src="https://github.com/user-attachments/assets/4ebc13b9-806b-47ed-a3f9-fbd9b3b59bf9" />

---

## Additional Notes

Bug list in discord

---
