### PR TITLE
Remove dark mode

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -15,15 +15,6 @@
     "Segoe UI Symbol", "Noto Color Emoji";
 }
 
-html,
-body {
-  @apply bg-white dark:bg-gray-950;
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
-}
-
 @utility font-figmaHand {
   font-family: "Patrick Hand", cursive;
 }


### PR DESCRIPTION
## 📝 Description

app.css was preferring dark mode if enabled in client browser.

The current figma design has no plans for a dark mode, so I removed dark mode related properties from app.css

---

## 📸 Screenshots (if applicable)

<img width="1719" height="984" alt="image" src="https://github.com/user-attachments/assets/e62b3a8d-b671-4480-85aa-21589e8423a2" />

<img width="1720" height="980" alt="image" src="https://github.com/user-attachments/assets/2db838ec-df79-4214-aec5-82aba1d9db3f" />